### PR TITLE
Ozon 55 hash password

### DIFF
--- a/configs/init.sql
+++ b/configs/init.sql
@@ -15,7 +15,7 @@ CREATE TABLE users (
     firstName TEXT,
     lastName TEXT,
     email TEXT NOT NULL,
-    password TEXT NOT NULL,
+    password BYTEA NOT NULL,
     avatar TEXT
 );
 
@@ -64,6 +64,7 @@ GRANT ALL PRIVILEGES ON TABLE users TO ozon_root;
 GRANT ALL PRIVILEGES ON TABLE category TO ozon_root;
 GRANT ALL PRIVILEGES ON TABLE products TO ozon_root;
 GRANT ALL PRIVILEGES ON TABLE subsetCategory TO ozon_root;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ozon_root;
 
 
 -- Data for testing

--- a/internal/pkg/models/user.go
+++ b/internal/pkg/models/user.go
@@ -7,7 +7,7 @@ type ProfileUser struct {
 	FirstName sql.NullString `json:"first_name"`
 	LastName  sql.NullString `json:"last_name"`
 	Email     string         `json:"email"`
-	Password  string         `json:"-"`
+	Password  []byte         `json:"-"`
 	Avatar    Avatar         `json:"avatar"`
 }
 

--- a/internal/pkg/user/repository.go
+++ b/internal/pkg/user/repository.go
@@ -7,7 +7,7 @@ import (
 //go:generate mockgen -destination=./mock/mock_repository.go -package=mock github.com/go-park-mail-ru/2021_1_DuckLuck/internal/pkg/user Repository
 
 type Repository interface {
-	AddProfile(user *models.SignupUser) (uint64, error)
+	AddProfile(user *models.ProfileUser) (uint64, error)
 	UpdateProfile(userId uint64, user *models.UpdateUser) error
 	SelectProfileByEmail(email string) (*models.ProfileUser, error)
 	SelectProfileById(userId uint64) (*models.ProfileUser, error)

--- a/internal/pkg/user/repository/postgresql_repository.go
+++ b/internal/pkg/user/repository/postgresql_repository.go
@@ -18,7 +18,7 @@ func NewSessionPostgresqlRepository(db *sql.DB) user.Repository {
 	}
 }
 
-func (pr *PostgresqlRepository) AddProfile(user *models.SignupUser) (uint64, error) {
+func (pr *PostgresqlRepository) AddProfile(user *models.ProfileUser) (uint64, error) {
 	row := pr.db.QueryRow(
 		"INSERT INTO users(email, password) VALUES ($1, $2) RETURNING id",
 		user.Email,

--- a/internal/pkg/user/usecase/usecase.go
+++ b/internal/pkg/user/usecase/usecase.go
@@ -7,8 +7,7 @@ import (
 	"github.com/go-park-mail-ru/2021_1_DuckLuck/internal/pkg/models"
 	"github.com/go-park-mail-ru/2021_1_DuckLuck/internal/pkg/user"
 	"github.com/go-park-mail-ru/2021_1_DuckLuck/internal/server/errors"
-
-	"golang.org/x/crypto/bcrypt"
+	"github.com/go-park-mail-ru/2021_1_DuckLuck/internal/server/tools"
 )
 
 type UserUseCase struct {
@@ -27,7 +26,7 @@ func (u *UserUseCase) Authorize(authUser *models.LoginUser) (*models.ProfileUser
 		return nil, errors.ErrIncorrectUserEmail
 	}
 
-	if err = bcrypt.CompareHashAndPassword([]byte(profileUser.Password), []byte(authUser.Password)); err != nil {
+	if ok := tools.CompareHashAndPassword(profileUser.Password, authUser.Password); !ok {
 		return nil, errors.ErrIncorrectUserPassword
 	}
 
@@ -76,13 +75,13 @@ func (u *UserUseCase) AddUser(user *models.SignupUser) (uint64, error) {
 		return 0, errors.ErrEmailAlreadyExist
 	}
 
-	hashOfPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.MinCost)
+	hashOfPassword, err := tools.GenerateHashFromPassword(user.Password)
 	if err != nil {
 		return 0, errors.ErrHashFunctionFailed
 	}
 
-	return u.UserRepo.AddProfile(&models.SignupUser{
+	return u.UserRepo.AddProfile(&models.ProfileUser{
 		Email:    user.Email,
-		Password: string(hashOfPassword),
+		Password: hashOfPassword,
 	})
 }

--- a/internal/server/tools/password_hasher.go
+++ b/internal/server/tools/password_hasher.go
@@ -1,0 +1,35 @@
+package tools
+
+import (
+	"bytes"
+	"crypto/rand"
+
+	"github.com/go-park-mail-ru/2021_1_DuckLuck/internal/server/errors"
+
+	"golang.org/x/crypto/argon2"
+)
+
+const (
+	times = 1
+	memory = 64 * 1024
+	threads = 4
+	keyLen = 32
+	saltLen = 8
+)
+
+func GenerateHashFromPassword(password string) ([]byte, error) {
+	salt := make([]byte, saltLen)
+	_, err := rand.Read(salt)
+	if err != nil {
+		return nil, errors.ErrServerSystem
+	}
+
+	hashedPassword := argon2.IDKey([]byte(password), salt, times, memory, threads, keyLen)
+	return append(salt, hashedPassword...), nil
+}
+
+func CompareHashAndPassword(hash []byte, password string) bool {
+	salt := hash[0:saltLen]
+	hashedPassword := argon2.IDKey([]byte(password), salt, times, memory, threads, keyLen)
+	return bytes.Equal(hashedPassword, hash[saltLen:])
+}


### PR DESCRIPTION
- Выделил утилиту `passwordHasher`, чтобы можно было легко подменить хэшер паролей. До этого использовался `bcrypt` заменил на `argon2`
- Теперь в бд пароль хранится не как строка, а как массив байт