### PR TITLE
OZON-80 Fix csrf token validation

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,7 +1,7 @@
 name: Build and deploy
 
 env:
-  TAG: v1.4
+  TAG: v1.5
 
 on:
   push:

--- a/internal/server/tools/hasher/hasher.go
+++ b/internal/server/tools/hasher/hasher.go
@@ -25,13 +25,6 @@ var (
 		keyLen:  64,
 		saltLen: 8,
 	}
-	csrfTokenSettings = &Settings{
-		times:   1,
-		memory:  1024,
-		threads: 4,
-		keyLen:  32,
-		saltLen: 4,
-	}
 )
 
 func GenerateHashFromPassword(password string) ([]byte, error) {
@@ -40,14 +33,6 @@ func GenerateHashFromPassword(password string) ([]byte, error) {
 
 func CompareHashAndPassword(hash []byte, password string) bool {
 	return compareHashAndSecret(hash, password, passwordSettings)
-}
-
-func GenerateHashFromCsrfToken(password string) ([]byte, error) {
-	return generateHashFromSecret(password, csrfTokenSettings)
-}
-
-func CompareHashAndCsrfToken(hash []byte, password string) bool {
-	return compareHashAndSecret(hash, password, csrfTokenSettings)
 }
 
 func generateHashFromSecret(secret string, settings *Settings) ([]byte, error) {


### PR DESCRIPTION
**Изменил:**
1. Убрал `аргон2` для проверки токена
2. Теперь клиенту в `body` выдаётся подписанный jwt токен и клиент при запросе на сервер выставляет его в хедере